### PR TITLE
Allow n8n for aarch64 (Raspberry Pi 4)

### DIFF
--- a/n8n/config.json
+++ b/n8n/config.json
@@ -3,7 +3,7 @@
   "version": "0.206.1",
   "slug": "hass-n8n",
   "description": "hass-n8n forked from Rbillon59 by niefuend",
-  "arch": ["amd64"],
+  "arch": ["amd64","aarch64"],
   "stage": "experimental",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:5678]/",
   "icon": "icon.png",


### PR DESCRIPTION
Tested on my local rpi4, all works well!